### PR TITLE
Marketing Category Added

### DIFF
--- a/APIs/openFDA API/openFDA API NDC Code Pull-No API Key.py
+++ b/APIs/openFDA API/openFDA API NDC Code Pull-No API Key.py
@@ -105,12 +105,13 @@ def process_data(results):
         generic_name = result.get("generic_name")
         brand_name = result.get("brand_name")
         packaging = result.get("packaging", [])
+        marketing_category = result.get("marketing_category")
         strength = result.get("active_ingredients", [{}])[0].get("strength")
         for package in packaging:
             package_ndc = package.get("package_ndc")
             description = package.get("description")
             drug_name_with_dose = (f'{generic_name} ' if generic_name else f'{brand_name} ') + (f'{strength} ' if strength else '')
-            records.append([package_ndc, drug_name_with_dose])
+            records.append([package_ndc, drug_name_with_dose, marketing_category])
     return records
 
 def main(keywords):
@@ -121,7 +122,7 @@ def main(keywords):
             records += process_data(results)
         else:
             print(f"No data found for keyword: {keyword} \n")
-    df = pd.DataFrame(records, columns=["NDC", "DrugNameWithDose"])
+    df = pd.DataFrame(records, columns=["NDC", "DrugNameWithDose", "MarketingCategory"])
     
         # Drop duplicate rows based on the 'NDC' column
     df.drop_duplicates(subset=['NDC'], inplace=True)


### PR DESCRIPTION
# Description 
This PR adds the "MarketingCategory" to the final output for the openFDA script. 

## What was the problem? 
openFDA should only return medications that are approved by the FDA.  Hannah encountered a medication that was not approved that openFDA returned, but the "marketing_category" variable denotes that it is "UNAPPROVED DRUG OTHER".

## How does this fix it? 
This PR includes the "marketing_category" variable in the final output of the openFDA query so that the analyst can manually check that the final output does not contain any NDC codes that may have yet to be removed from openFDA and are marked as "Unapproved Drug Other" or other possible string combinations that denote that the drug is not FDA approved. 

## Jira Tickets
- None 

## How to test this PR 
- Run an openFDA script query and ensure that the new column "MarketingCategory" appears in the third column of the final excel output. 