### PR TITLE
Single line change to parsing script, removes whitespace in Code Set …

### DIFF
--- a/utils/new_parsing_script.py
+++ b/utils/new_parsing_script.py
@@ -1,8 +1,8 @@
 import pandas as pd
 
 
-Name_of_Code_Set = "Musc Hip" # Enter name of condition(Arrythmias, GI Cancer etc.)
-file_name = "musc_hip"  #Enter file name stored in input folder
+Name_of_Code_Set = "" # Enter name of condition(Arrythmias, GI Cancer etc.)
+file_name = ""  #Enter file name stored in input folder
 
 input_directory = f"codeset/input/{file_name}.xlsx"
 output_directory = f"codeset/output/{Name_of_Code_Set}.txt"
@@ -12,6 +12,7 @@ default = pd.read_excel(input_directory, sheet_name="Code Set Details")
 df = default.drop(default[default['In CDW'] == 'No'].index)
 
 #splitting phrases if they have a semicolon
+df['Code Set'] = df['Code Set'].str.split().str.join("")
 
 df['CFR Criteria'] = df['CFR Criteria'].str.split('; ')
 df = df.explode('CFR Criteria')


### PR DESCRIPTION
Description
This PR adds the a line to remove whitespace in the Code set column(ICD-9,CPT etc.)

What was the problem?
There was whitespace causing a few codes to not be processed by the parsing script. 

How does this fix it?
Removes the white space in that column

Jira Tickets - MCP 7094

How to test this PR
Run the script with the excel file attached here. This file contains white space in a few of the cells of the Code Set column. 
[varicose_veins.xlsx](https://github.com/user-attachments/files/17757264/varicose_veins.xlsx)
