### PR TITLE
RxNorm length 5 or more filter

### DIFF
--- a/APIs/UMLS API/Single Pulls/UMLS RxNorm.py
+++ b/APIs/UMLS API/Single Pulls/UMLS RxNorm.py
@@ -177,6 +177,8 @@ RxNorm_full_grouped = RxNorm_trans_df_clean.groupby('Code').agg({
     'Keyword': lambda x: '; '.join(x.astype(str).unique())
 }).reset_index()
 
+RxNorm_full_grouped = RxNorm_full_grouped[RxNorm_full_grouped["Code"].str.len() >= 5]
+
 ## Save file
 outpath = 'output/'
 file_name = f"{Condition}_RxNorm_codes.xlsx"


### PR DESCRIPTION
# Description 
Adds a filter to the RxNorm script that will only return the RxNorm if it has a length of 5 character or more. 

## What was the problem? 
The client requested that we only include RxNorm codes that contain a length of 5 characters or more moving forward.

## How does this fix it? 
This ensures that the RxNorm script does not return RxNorm codes that are less than 5 characters. 

## Jira Tickets
- [MCP-7362](https://amida.atlassian.net/browse/MCP-7362)

## How to test this PR 
- Find a medication title that contains RxNorm codes that are less than a length of 5 characters (I used "Aspirin" to test this)
- Run the old script, then run the new script, and compare the output to ensure that RxNorm codes that have a length of less than 5 characters are not returned. 

[MCP-7362]: https://amida.atlassian.net/browse/MCP-7362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ