### PR TITLE
adding in try/except blocks for JsonDecode Errors

### DIFF
--- a/APIs/UMLS API/Single Pulls/UMLS CPT.py
+++ b/APIs/UMLS API/Single Pulls/UMLS CPT.py
@@ -15,6 +15,7 @@ import argparse
 import numpy as np
 import pandas as pd
 import os
+from json.decoder import JSONDecodeError
 version = 'current'
 
 # Keyword Column Name
@@ -136,30 +137,34 @@ for idx, cui in enumerate(cui_list):
             page += 1
             path = '/search/'+version
             query = {'apiKey':apikey, 'string':cui, 'sabs':sabs, 'returnIdType':'code', 'pageNumber':page}
-            output = requests.get(base_uri+path, params=query)
-            output.encoding = 'utf-8'
-            #print(output.url)
-        
-            outputJson = output.json()
-        
-            results = (([outputJson['result']])[0])['results']
-                    
-            if len(results) == 0:
-                if page == 1:
-                    #print('No results found for ' + cui +'\n')
-                    # o.write('No results found.' + '\n' + '\n')
-                    break
-                else:
-                    break
-                    
-            for item in results:
-                CPT_keyword.append(keyword_value)
-                CPT_DC_Code.append(dc_code)
-                CPT_CFR_criteria.append(cfr_criteria)
-                CPT_data_concept.append(data_concept)
-                CPT_code.append(item['ui'])
-                CPT_name.append(item['name'])
-                CPT_root.append(item['rootSource'])
+            try:
+                output = requests.get(base_uri+path, params=query)
+                output.encoding = 'utf-8'
+                #print(output.url)
+            
+                outputJson = output.json()
+            
+                results = (([outputJson['result']])[0])['results']
+                        
+                if len(results) == 0:
+                    if page == 1:
+                        #print('No results found for ' + cui +'\n')
+                        # o.write('No results found.' + '\n' + '\n')
+                        break
+                    else:
+                        break
+                        
+                for item in results:
+                    CPT_keyword.append(keyword_value)
+                    CPT_DC_Code.append(dc_code)
+                    CPT_CFR_criteria.append(cfr_criteria)
+                    CPT_data_concept.append(data_concept)
+                    CPT_code.append(item['ui'])
+                    CPT_name.append(item['name'])
+                    CPT_root.append(item['rootSource'])
+            except JSONDecodeError:
+                print(f"JSONDecodeError encountered for CUI: {cui}. Skipping this entry.")
+                break  # Exit the while loop for this `cui` and proceed to the next one
 
 CPT_trans_df = pd.DataFrame({"VASRD Code": CPT_DC_Code, "Data Concept": CPT_data_concept, "CFR Criteria": CPT_CFR_criteria, "Code Set": CPT_root, "Code": CPT_code, "Code Description": CPT_name, "Keyword": CPT_keyword})
 

--- a/APIs/UMLS API/Single Pulls/UMLS SNOMED-CT.py
+++ b/APIs/UMLS API/Single Pulls/UMLS SNOMED-CT.py
@@ -15,6 +15,7 @@ import argparse
 import numpy as np
 import pandas as pd
 import os
+from json.decoder import JSONDecodeError
 version = 'current'
 
 # Keyword Column Name
@@ -136,30 +137,34 @@ for idx, cui in enumerate(cui_list):
             page += 1
             path = '/search/'+version
             query = {'apiKey':apikey, 'string':cui, 'sabs':sabs, 'returnIdType':'code', 'pageNumber':page}
-            output = requests.get(base_uri+path, params=query)
-            output.encoding = 'utf-8'
-            #print(output.url)
-        
-            outputJson = output.json()
-        
-            results = (([outputJson['result']])[0])['results']
-                    
-            if len(results) == 0:
-                if page == 1:
-                    #print('No results found for ' + cui +'\n')
-                    # o.write('No results found.' + '\n' + '\n')
-                    break
-                else:
-                    break
-                    
-            for item in results:
-                SNOMED_CT_keyword.append(keyword_value)
-                SNOMED_CT_DC_Code.append(dc_code)
-                SNOMED_CT_CFR_criteria.append(cfr_criteria)
-                SNOMED_CT_data_concept.append(data_concept)
-                SNOMED_CT_code.append(item['ui'])
-                SNOMED_CT_name.append(item['name'])
-                SNOMED_CT_root.append(item['rootSource'])
+            try:
+                output = requests.get(base_uri+path, params=query)
+                output.encoding = 'utf-8'
+                #print(output.url)
+            
+                outputJson = output.json()
+            
+                results = (([outputJson['result']])[0])['results']
+                        
+                if len(results) == 0:
+                    if page == 1:
+                        #print('No results found for ' + cui +'\n')
+                        # o.write('No results found.' + '\n' + '\n')
+                        break
+                    else:
+                        break
+                        
+                for item in results:
+                    SNOMED_CT_keyword.append(keyword_value)
+                    SNOMED_CT_DC_Code.append(dc_code)
+                    SNOMED_CT_CFR_criteria.append(cfr_criteria)
+                    SNOMED_CT_data_concept.append(data_concept)
+                    SNOMED_CT_code.append(item['ui'])
+                    SNOMED_CT_name.append(item['name'])
+                    SNOMED_CT_root.append(item['rootSource'])
+            except JSONDecodeError:
+                print(f"JSONDecodeError encountered for CUI: {cui}. Skipping this entry.")
+                break  # Exit the while loop for this `cui` and proceed to the next one
 
 SNOMED_CT_trans_df = pd.DataFrame({"VASRD Code": SNOMED_CT_DC_Code, "Data Concept": SNOMED_CT_data_concept, "CFR Criteria": SNOMED_CT_CFR_criteria, "Code Set": SNOMED_CT_root, "Code": SNOMED_CT_code, "Code Description": SNOMED_CT_name, "Keyword": SNOMED_CT_keyword})
 


### PR DESCRIPTION
Unfortunately, the JSONDecodeError still persists in CPT, Snomed and LOINC UMLS scripts. Alyssa has found a temporary workaround that slows down the script enough for the API call to process the request resulting in no JSONDecodeError. The CPT, LOINC and SNOMED scripts now have an extra try/except block integrated into them. 